### PR TITLE
continue instead of returning when doing product page captcha

### DIFF
--- a/sites/walmart.py
+++ b/sites/walmart.py
@@ -48,7 +48,7 @@ class Walmart:
                     if self.is_captcha(r.text):
                         self.status_signal.emit({"msg":"CAPTCHA - Opening Product Page","status":"error"})
                         self.handle_captcha(self.product)
-                        return
+                        continue
 
                     doc = lxml.html.fromstring(r.text)
                     if not image_found:


### PR DESCRIPTION
Returning with nothing in this function causes an unpack error because this function is expected to return 3 values, let's just continue and do another loop instead of returning