### PR TITLE
Fixing broken requirements chromedriver-py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ lxml==4.5.0
 darkdetect==0.1.1
 colorama==0.4.3
 selenium==3.141.0
-chromedriver-py==86.0.4240.198
+chromedriver-py==86.0.4240.22
 pycryptodome
 webdriver_manager==3.2.2


### PR DESCRIPTION
The version specified in requirements.txt does not actually exist. While that chrome version exists, the chromedriver-py version does not. Reference of available versions:
https://pypi.org/project/chromedriver-py/#history