### PR TITLE
fix target setting keys and login/payment steps in checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# OSX
+.DS_Store

--- a/pages/settingspage.py
+++ b/pages/settingspage.py
@@ -166,10 +166,10 @@ class SettingsPage(QtWidgets.QWidget):
             settings.random_delay_start = settings_data["random_delay_start"]
         if settings_data.get("random_delay_stop", "") != "":
             settings.random_delay_stop = settings_data["random_delay_stop"]
-        if settings_data.get("target_user_edit", "") != "":
+        if settings_data.get("target_user", "") != "":
             settings.target_user = settings_data["target_user"]
-        if settings_data.get("target_pass_edit", "") != "":
-            settings.target_pass = settings_data["target_pass"]
+        if settings_data.get("target_pass", "") != "":
+            settings.target_pass = (Encryption().decrypt(settings_data["target_pass"].encode("utf-8"))).decode("utf-8")
         if settings_data.get("gamestop_user", "") != "":
             settings.gamestop_user = settings_data["gamestop_user"]
         if settings_data.get("gamestop_pass", "") != "":

--- a/sites/target.py
+++ b/sites/target.py
@@ -29,9 +29,9 @@ class Target:
 
         if not settings.dont_buy:
             self.submit_order()
+            send_webhook("OP", "Target", self.profile["profile_name"], self.task_id, self.product_image)
         else:
             self.status_signal.emit(create_msg("Mock Order Placed", "success"))
-            send_webhook("OP", "Target", self.profile["profile_name"], self.task_id, self.product_image)
 
     def init_driver(self):
         driver_manager = ChromeDriverManager()

--- a/sites/target.py
+++ b/sites/target.py
@@ -53,8 +53,8 @@ class Target:
     def login(self):
         self.browser.get("https://www.target.com")
         self.browser.find_element_by_id("account").click()
-        wait(self.browser, 3).until(EC.element_to_be_clickable((By.ID, "accountNav-signIn"))).click()
-        wait(self.browser, 3).until(EC.presence_of_element_located((By.ID, "username"))).send_keys(settings.target_user)
+        wait(self.browser, 10).until(EC.element_to_be_clickable((By.ID, "accountNav-signIn"))).click()
+        wait(self.browser, 10).until(EC.presence_of_element_located((By.ID, "username"))).send_keys(settings.target_user)
         password = self.browser.find_element_by_id("password")
         password.send_keys(settings.target_pass)
         self.browser.find_element_by_id("login").click()
@@ -137,19 +137,21 @@ class Target:
             try:
                 cc_input = self.browser.find_element_by_id("creditCardInput-cardNumber")
                 cc_input.send_keys(self.profile["card_number"])
-                self.browser.find_element_by_xpath('//button[@data-test= "verify-card-button"]').click()
+                if len(self.browser.find_elements_by_xpath('//button[@data-test= "verify-card-button"]')) > 0:
+                    self.browser.find_element_by_xpath('//button[@data-test= "verify-card-button"]').click()
                 added_cc = True
             except:
                 self.status_signal.emit(create_msg("CC Verification not needed", "normal"))
-                return
+                break
 
         while not added_cvv:
             try:
-                cvv_input = self.browser.find_element_by_xpath("input[@data-test= 'credit-card-cvv-input']")
+                cvv_input = self.browser.find_element_by_id("creditCardInput-cvv")
                 self.status_signal.emit(create_msg("Entering CC Last 3", "normal"))
+                cvv_input.send_keys(self.profile["card_cvv"])
 
-                cvv_input.send_keys(self.profile["card-cvv"])
-                self.browser.find_element_by_xpath('//button[@data-test= "save-and-continue-button"]').click()
+                if len(self.browser.find_elements_by_xpath('//button[@data-test= "save-and-continue-button"]')) > 0:
+                    self.browser.find_element_by_xpath('//button[@data-test= "save-and-continue-button"]').click()
                 added_cvv = True
             except:
                 self.status_signal.emit(create_msg("No need to enter last 3", "normal"))


### PR DESCRIPTION
targets checkout was using the wrong setting vars for login credentials and the checkout process wasnt entering the credit card information correctly.

I only tested checkout with the card i already had saved to my profile, i think not having one saved also needs the expiration date

also moved the webhook out of test mode and into normal checkout