### PR TITLE
Removed potential for settings.json to conflict upstream:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,12 @@
+# Avoid user data, include defaults
+data/*
+*.json
+!*_default.json
 __pycache__/
 debug.log
 
-#Data folder
-data/profiles.json
-data/settings.json
-data/proxies.json
-data/tasks.json
-data/vault.json
-
+# IDEs
+.idea/
 # Environments
 .env
 .venv

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,1 +1,0 @@
-{"webhook": "", "webhookonbrowser": true, "webhookonorder": true, "webhookonfailed": true, "browseronfailed": true, "onlybuyone": true, "dont_buy": true, "random_delay_start": "", "random_delay_stop": ""}

--- a/data/settings_default.json
+++ b/data/settings_default.json
@@ -1,0 +1,1 @@
+{"webhook": "", "webhookonbrowser": true, "webhookonorder": true, "webhookonfailed": true, "browseronfailed": true, "onlybuyone": true, "dont_buy": true, "random_delay_start": "", "random_delay_stop": ""}

--- a/data/settings_default.json
+++ b/data/settings_default.json
@@ -1,1 +1,1 @@
-{"webhook": "", "webhookonbrowser": true, "webhookonorder": true, "webhookonfailed": true, "browseronfailed": true, "onlybuyone": true, "dont_buy": true, "random_delay_start": "", "random_delay_stop": ""}
+{"webhook": "", "webhookonbrowser": true, "webhookonorder": true, "webhookonfailed": true, "browseronfailed": true, "bb_ac_beta": false, "onlybuyone": true, "dont_buy": true, "random_delay_start": "", "random_delay_stop": ""}

--- a/pages/settingspage.py
+++ b/pages/settingspage.py
@@ -1,18 +1,27 @@
-from theming.styles import globalStyles
+import platform
+import settings
+import sys
+
 from PyQt5 import QtCore, QtGui, QtWidgets
-from utils import return_data,write_data,Encryption
-import sys,platform,settings
+
+from theming.styles import globalStyles
+from utils import return_data, write_data, Encryption, data_exists, BirdLogger, validate_data
+
 
 def no_abort(a, b, c):
     sys.__excepthook__(a, b, c)
+
+
 sys.excepthook = no_abort
+logger = BirdLogger()
+
 
 class SettingsPage(QtWidgets.QWidget):
     def __init__(self, parent=None):
         super(SettingsPage, self).__init__(parent)
         self.header_font = self.create_font("Arial", 18)
         self.small_font = self.create_font("Arial", 13)
-        self.setupUi(self)
+        self.setup_ui(self)
 
     def create_font(self, family, pt_size) -> QtGui.QFont:
         font = QtGui.QFont()
@@ -46,26 +55,29 @@ class SettingsPage(QtWidgets.QWidget):
         edit.setAttribute(QtCore.Qt.WA_MacShowFocusRect, 0)
         return edit
 
-    def setupUi(self, settingspage):
+    def setup_ui(self, settingspage):
         self.settingspage = settingspage
         self.settingspage.setAttribute(QtCore.Qt.WA_StyledBackground, True)
         self.settingspage.setGeometry(QtCore.QRect(60, 0, 1041, 601))
-        self.settingspage.setStyleSheet("QComboBox::drop-down {    border: 0px;}QComboBox::down-arrow {    image: url(images/down_icon.png);    width: 14px;    height: 14px;}QComboBox{    padding: 1px 0px 1px 3px;}QLineEdit:focus {   border: none;   outline: none;}")
+        self.settingspage.setStyleSheet(
+            "QComboBox::drop-down {    border: 0px;}QComboBox::down-arrow {    image: url(images/down_icon.png);    width: 14px;    height: 14px;}QComboBox{    padding: 1px 0px 1px 3px;}QLineEdit:focus {   border: none;   outline: none;}")
         self.settings_card = QtWidgets.QWidget(self.settingspage)
         self.settings_card.setGeometry(QtCore.QRect(30, 70, 941, 501))
         self.settings_card.setFont(self.small_font)
         self.settings_card.setStyleSheet("background-color: #232323;border-radius: 20px;border: 1px solid #2e2d2d;")
 
         self.webhook_edit = self.create_edit(self.settings_card, QtCore.QRect(30, 50, 411, 21), self.small_font,
-                                                  "Webhook Link")
+                                             "Webhook Link")
         self.webhook_header = self.create_header(self.settings_card, QtCore.QRect(20, 10, 101, 31), self.header_font,
                                                  "Webhook")
-        
+
         self.savesettings_btn = QtWidgets.QPushButton(self.settings_card)
         self.savesettings_btn.setGeometry(QtCore.QRect(190, 450, 86, 32))
         self.savesettings_btn.setFont(self.small_font)
         self.savesettings_btn.setCursor(QtGui.QCursor(QtCore.Qt.PointingHandCursor))
-        self.savesettings_btn.setStyleSheet("color: #FFFFFF;background-color: {};border-radius: 10px;border: 1px solid #2e2d2d;".format(globalStyles["primary"]))
+        self.savesettings_btn.setStyleSheet(
+            "color: #FFFFFF;background-color: {};border-radius: 10px;border: 1px solid #2e2d2d;".format(
+                globalStyles["primary"]))
         self.savesettings_btn.setText("Save")
         self.savesettings_btn.clicked.connect(self.save_settings)
 
@@ -86,23 +98,36 @@ class SettingsPage(QtWidgets.QWidget):
         self.proxies_header = self.create_header(self.settingspage, QtCore.QRect(30, 10, 81, 31),
                                                  self.create_font("Arial", 22), "Settings")
         self.bestbuy_user_edit = self.create_edit(self.settings_card, QtCore.QRect(300, 310, 235, 20),
-                                                 self.small_font, "Bestbuy.com Username (Email)")
+                                                  self.small_font, "Bestbuy.com Username (Email)")
         self.bestbuy_pass_edit = self.create_edit(self.settings_card, QtCore.QRect(300, 335, 235, 20),
-                                                 self.small_font, "Bestbuy.com Password")
+                                                  self.small_font, "Bestbuy.com Password")
         self.target_user_edit = self.create_edit(self.settings_card, QtCore.QRect(30, 365, 235, 20),
                                                  self.small_font, "Target.com Username (Email/Cell #)")
         self.target_pass_edit = self.create_edit(self.settings_card, QtCore.QRect(30, 390, 235, 20),
                                                  self.small_font, "Target.com Password")
         self.gamestop_user_edit = self.create_edit(self.settings_card, QtCore.QRect(300, 365, 235, 20),
-                                                 self.small_font, "Gamestop.com Username (Email)")
+                                                   self.small_font, "Gamestop.com Username (Email)")
         self.gamestop_pass_edit = self.create_edit(self.settings_card, QtCore.QRect(300, 390, 235, 20),
-                                                 self.small_font, "Gamestop.com Password")
-        
+                                                   self.small_font, "Gamestop.com Password")
+
         self.set_data()
         QtCore.QMetaObject.connectSlotsByName(settingspage)
 
     def set_data(self):
-        settings = return_data("./data/settings.json")
+
+        settings_default = return_data("./data/settings_default.json")
+        if data_exists("./data/settings.json"):
+            settings = return_data("./data/settings.json")
+        else:
+            logger.alt("Set-Settings-Data", "No existing settings found to be parsed, creating new from default.")
+            write_data("./data/settings.json", settings_default)
+            settings = return_data("./data/settings.json")
+
+        if not validate_data(settings, settings_default):
+            logger.error("Set-Settings-Data", "Parsed settings data is malformed! "
+                                              "This will most likely cause a fatal exception. "
+                                              "Try removing existing settings.json")
+
         self.webhook_edit.setText(settings["webhook"])
         if settings["webhookonbrowser"]:
             self.browser_checkbox.setChecked(True)
@@ -127,7 +152,8 @@ class SettingsPage(QtWidgets.QWidget):
             self.bestbuy_user_edit.setText("")
 
         try:
-            self.bestbuy_pass_edit.setText((Encryption().decrypt(settings["bestbuy_pass"].encode("utf-8"))).decode("utf-8"))
+            self.bestbuy_pass_edit.setText(
+                (Encryption().decrypt(settings["bestbuy_pass"].encode("utf-8"))).decode("utf-8"))
         except:
             self.bestbuy_pass_edit.setText("")
 
@@ -137,32 +163,34 @@ class SettingsPage(QtWidgets.QWidget):
             self.target_user_edit.setText("")
 
         try:
-            self.target_pass_edit.setText((Encryption().decrypt(settings["target_pass"].encode("utf-8"))).decode("utf-8"))
+            self.target_pass_edit.setText(
+                (Encryption().decrypt(settings["target_pass"].encode("utf-8"))).decode("utf-8"))
         except:
             self.target_pass_edit.setText("")
-        
+
         try:
             self.gamestop_user_edit.setText(settings["gamestop_user"])
         except:
             self.gamestop_user_edit.setText("")
 
         try:
-            self.gamestop_pass_edit.setText((Encryption().decrypt(settings["gamestop_pass"].encode("utf-8"))).decode("utf-8"))
+            self.gamestop_pass_edit.setText(
+                (Encryption().decrypt(settings["gamestop_pass"].encode("utf-8"))).decode("utf-8"))
         except:
             self.gamestop_pass_edit.setText("")
 
         self.update_settings(settings)
 
     def save_settings(self):
-        settings = {"webhook":            self.webhook_edit.text(),
-                    "webhookonbrowser":   self.browser_checkbox.isChecked(),
-                    "webhookonorder":     self.order_checkbox.isChecked(),
-                    "webhookonfailed":    self.paymentfailed_checkbox.isChecked(),
-                    "browseronfailed":    self.onfailed_checkbox.isChecked(),
-                    "onlybuyone":         self.buy_one_checkbox.isChecked(),
-                    "dont_buy":           self.dont_buy_checkbox.isChecked(),
+        settings = {"webhook": self.webhook_edit.text(),
+                    "webhookonbrowser": self.browser_checkbox.isChecked(),
+                    "webhookonorder": self.order_checkbox.isChecked(),
+                    "webhookonfailed": self.paymentfailed_checkbox.isChecked(),
+                    "browseronfailed": self.onfailed_checkbox.isChecked(),
+                    "onlybuyone": self.buy_one_checkbox.isChecked(),
+                    "dont_buy": self.dont_buy_checkbox.isChecked(),
                     "random_delay_start": self.random_delay_start.text(),
-                    "random_delay_stop":  self.random_delay_stop.text(),
+                    "random_delay_stop": self.random_delay_stop.text(),
                     "bestbuy_user": self.bestbuy_user_edit.text(),
                     "bestbuy_pass": Encryption().encrypt(self.bestbuy_pass_edit.text()).decode("utf-8"),
                     "target_user": self.target_user_edit.text(),
@@ -170,13 +198,15 @@ class SettingsPage(QtWidgets.QWidget):
                     "gamestop_user": self.gamestop_user_edit.text(),
                     "gamestop_pass": Encryption().encrypt(self.gamestop_pass_edit.text()).decode("utf-8")}
 
-        write_data("./data/settings.json",settings)
+        write_data("./data/settings.json", settings)
         self.update_settings(settings)
         QtWidgets.QMessageBox.information(self, "Phoenix Bot", "Saved Settings")
 
     def update_settings(self, settings_data):
         global webhook, webhook_on_browser, webhook_on_order, webhook_on_failed, browser_on_failed, dont_buy, random_delay_start, random_delay_stop, target_user, target_pass, gamestop_user, gamestop_pass
-        settings.webhook, settings.webhook_on_browser, settings.webhook_on_order, settings.webhook_on_failed, settings.browser_on_failed, settings.buy_one, settings.dont_buy = settings_data["webhook"], settings_data["webhookonbrowser"], settings_data["webhookonorder"], settings_data["webhookonfailed"], settings_data["browseronfailed"], settings_data['onlybuyone'], settings_data['dont_buy']
+        settings.webhook, settings.webhook_on_browser, settings.webhook_on_order, settings.webhook_on_failed, settings.browser_on_failed, settings.buy_one, settings.dont_buy = \
+        settings_data["webhook"], settings_data["webhookonbrowser"], settings_data["webhookonorder"], settings_data[
+            "webhookonfailed"], settings_data["browseronfailed"], settings_data['onlybuyone'], settings_data['dont_buy']
 
         if settings_data.get("random_delay_start", "") != "":
             settings.random_delay_start = settings_data["random_delay_start"]
@@ -185,7 +215,8 @@ class SettingsPage(QtWidgets.QWidget):
         if settings_data.get("bestbuy_user", "") != "":
             settings.bestbuy_user = settings_data["bestbuy_user"]
         if settings_data.get("bestbuy_pass", "") != "":
-            settings.bestbuy_pass = (Encryption().decrypt(settings_data["bestbuy_pass"].encode("utf-8"))).decode("utf-8")
+            settings.bestbuy_pass = (Encryption().decrypt(settings_data["bestbuy_pass"].encode("utf-8"))).decode(
+                "utf-8")
         if settings_data.get("target_user", "") != "":
             settings.target_user = settings_data["target_user"]
         if settings_data.get("target_pass", "") != "":
@@ -193,4 +224,5 @@ class SettingsPage(QtWidgets.QWidget):
         if settings_data.get("gamestop_user", "") != "":
             settings.gamestop_user = settings_data["gamestop_user"]
         if settings_data.get("gamestop_pass", "") != "":
-            settings.gamestop_pass = (Encryption().decrypt(settings_data["gamestop_pass"].encode("utf-8"))).decode("utf-8")
+            settings.gamestop_pass = (Encryption().decrypt(settings_data["gamestop_pass"].encode("utf-8"))).decode(
+                "utf-8")

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,16 +1,17 @@
-try:
-    from Crypto import Random
-    from Crypto.Cipher import AES
-except:
-    from Cryptodome import Random
-    from Cryptodome.Cipher import AES
-from colorama import init, Fore
+import base64
 from datetime import datetime
-from selenium.webdriver import Chrome, ChromeOptions
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from webhook import DiscordWebhook, DiscordEmbed
-from chromedriver_py import binary_path as driver_path
-import json, platform, random, settings, threading, hashlib, base64, string, re
+import hashlib
+import json
+import platform
+import random
+import string
+
+from Crypto import Random
+from Crypto.Cipher import AES
+from colorama import Fore, init
+
+import settings
+from webhook import DiscordEmbed, DiscordWebhook
 
 normal_color = Fore.CYAN
 
@@ -37,12 +38,13 @@ if platform.system() == "Windows":
 else:
     init()
 
-print(
-    normal_color + "Welcome To Phoenix Bot - In times of crisis, the wise build bridges while the foolish build barriers.")
+print(normal_color + "Welcome To Phoenix Bot - In times of crisis, "
+                     "the wise build bridges while the foolish build barriers.")
 
 
 class BirdLogger:
-    def ts(self):
+    @staticmethod
+    def ts():
         return str(datetime.now())[:-7]
 
     def normal(self, task_id, msg):
@@ -70,7 +72,8 @@ class Encryption:
         aes = AES.new(self.trans(e_key), AES.MODE_CFB, IV)
         return aes.decrypt(msg[BLOCK_SIZE:])
 
-    def trans(self, key):
+    @staticmethod
+    def trans(key):
         return hashlib.md5(key).digest()
 
 
@@ -84,6 +87,18 @@ def return_data(path):
         with open(path, "r") as file:
             data = json.load(file)
         return data
+
+
+def validate_data(test_data, control_data):
+    return test_data.keys() == control_data.keys()
+
+
+def data_exists(path):
+    try:
+        open(path, "r")
+        return True
+    except FileNotFoundError:
+        return False
 
 
 def get_profile(profile_name):
@@ -147,10 +162,11 @@ def send_webhook(webhook_type, site, profile, task_id, image_url):
         except:
             pass
 
+
 def random_delay(delay, start, stop):
     """
     Returns the delay argument combined with a random number between start
-    and stop dividied by 1000.
+    and stop divided by 1000.
     """
     return delay + (random.randint(int(start), int(stop)) / 1000)
 


### PR DESCRIPTION

### From #73 
> ### Issue 
> In its current form the "settings.json" gets overwritten with what the user configures. However, this repository treats "settings.json" as a default configuration. This makes a contributor/tester's "settings.json" conflict with the upstream "settings.json" after they run the application.
>
> ### Proposal:
> I propose that the settings be moved to a "settings_default.json" that will go unchanged by any user behavior and the "settings.json" be added to the ".gitignore" in order to alleviate any annoyance with pushing back upstream.
----
### Changes Made:
- Moved settings.json to settings_default.json .
- Added settings.json to .gitignore and specifically permitted the new settings_default.json .
- Added IDE project folders to .gitignore .
- Added ability for settingspage.py to detect missing settings.json and generate a new one from the default.
- Added ability for settingspage.py to detect and warn about malformed settings.json .
- Added function in utils.__init__.py to check whether or not a file exists in expected path.
- Added function in utils.__init__.py to validate json data with expected keys.
- Import optimization on settingspage.py & utils.__init__.py .
- Proper Python Style Guide formatting pass on settingspage.py & utils.__init__.py .